### PR TITLE
Add copy-to-clipboard email feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,9 @@
                 <div class="contact-info">
                     <div class="contact-item">
                         <span>📧</span>
-                        <a href="mailto:stanimir1990@gmail.com">stanimir1990@gmail.com</a>
+                        <a id="email-link" href="mailto:stanimir1990@gmail.com">stanimir1990@gmail.com</a>
+                        <button id="copy-email-btn" class="copy-email-btn" aria-label="Copy email address">📋</button>
+                        <span id="copy-email-msg" class="copy-email-msg" role="status"></span>
                     </div>
                     <div class="contact-item">
                         <span>📍</span>

--- a/script.js
+++ b/script.js
@@ -58,4 +58,33 @@ document.addEventListener('DOMContentLoaded', function() {
             content.classList.toggle('collapsed');
         });
     });
+
+    // Email copy to clipboard
+    const copyEmailBtn = document.getElementById('copy-email-btn');
+    const emailLink = document.getElementById('email-link');
+    const copyEmailMsg = document.getElementById('copy-email-msg');
+
+    if (copyEmailBtn && emailLink && copyEmailMsg) {
+        copyEmailBtn.addEventListener('click', () => {
+            const email = emailLink.textContent.trim();
+            navigator.clipboard.writeText(email).then(() => {
+                copyEmailMsg.textContent = 'Email copied!';
+                copyEmailMsg.classList.add('visible');
+
+                setTimeout(() => {
+                    copyEmailMsg.classList.remove('visible');
+                    copyEmailMsg.textContent = '';
+                }, 2000);
+            }).catch(err => {
+                console.error('Failed to copy: ', err);
+                copyEmailMsg.textContent = 'Copy failed';
+                copyEmailMsg.classList.add('visible');
+
+                setTimeout(() => {
+                    copyEmailMsg.classList.remove('visible');
+                    copyEmailMsg.textContent = '';
+                }, 2000);
+            });
+        });
+    }
 });

--- a/style.css
+++ b/style.css
@@ -191,6 +191,30 @@ input:checked + .slider:before {
     gap: 0.5rem;
 }
 
+.copy-email-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1rem;
+    color: var(--link-color);
+}
+
+.copy-email-btn:hover {
+    text-decoration: underline;
+}
+
+.copy-email-msg {
+    margin-left: 0.5rem;
+    color: var(--accent-color);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    font-size: 0.9rem;
+}
+
+.copy-email-msg.visible {
+    opacity: 1;
+}
+
 .section {
     margin-bottom: 2rem;
 }


### PR DESCRIPTION
## Summary
- add copy button and message to contact email
- include CSS and JS to copy email address to clipboard

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68942ffca96c8330a5e68fd1c019bb4c